### PR TITLE
Index page beautification 2

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -7,9 +7,11 @@
   background-image: linear-gradient(rgba(0,0,0,0.4), rgba(0,0,0,0.4)), image-url("friends.jpeg");
   background-size: cover;
   h1 {
-    color: white;
+    font-size: 70px;
     font-weight: bolder;
-    font-size: 45px;
+    background: -webkit-linear-gradient(-70deg, #a2facf 0%, #64acff 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
   }
   p {
     color: white;

--- a/app/assets/stylesheets/components/_beacon_card.scss
+++ b/app/assets/stylesheets/components/_beacon_card.scss
@@ -11,7 +11,7 @@
 .card {
   background: linear-gradient(183deg, #e2fbf1, #ffffff);
   display: flex;
-  height: 10vh;
+  // height: 10vh; origin card size, can be use for javascript later.
   border-radius: 1px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
   margin: 5px 10px 0px 5px;
@@ -21,6 +21,19 @@
     display: flex;
     align-items: center;
     justify-content: space-evenly;
+  }
+  .card-user-beacon-details {
+    display: flex;
+    flex-direction: column;
+    margin: 20px 0px 10px 20px;
+
+    hr {
+      margin: 3px 30px 6px 0px;
+    }
+
+    p {
+      margin: 4px 0px 2px 0px;
+    }
   }
 }
 

--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -15,7 +15,6 @@
   }
 
   .custom-btn {
-    margin: 15px 10px;
     position: relative;
     display: inline-block;
     padding: 0.8em 0.8em;

--- a/app/assets/stylesheets/components/_messages.scss
+++ b/app/assets/stylesheets/components/_messages.scss
@@ -70,16 +70,17 @@ input.form-control {
 }
 
 .chat-header {
-  background: linear-gradient(135deg, #71bea0, #66FCF1);
-  color: white;
-  padding: 10px 20px;
-  margin-top: 10px;
-  border-radius: 14px;
+    background: linear-gradient(183deg, #6cc9ac, #ffffff);
+    color: white;
+    padding: 10px 20px;
+    margin-top: 10px;
+    border-radius: 14px;
   h4 {
     padding-top: 10px;
   }
 
   p {
+    display: inline-block;
     font-size: 16px;
     font-weight: bolder;
     color: #777777;

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -3,7 +3,10 @@
   background: white;
 
   .nav-item-str {
-    padding: 3px 0px 0px 2px;
+    padding: 14px 20px 0px 2px;
+    p {
+
+    }
     }
 }
 

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -5,7 +5,11 @@
   .nav-item-str {
     padding: 14px 20px 0px 2px;
     p {
-
+      span {
+        font-size: 16px;
+        color: darkturquoise;
+        font-weight: 700;
+      }
     }
     }
 }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -19,11 +19,16 @@ require("channels")
 import { initRadarCable } from "../channels/radar_channel";
 import { initMapbox } from '../packs/map';
 import { initGeocoding } from '../packs/geocoding';
+// import { cardExtendDetails } from "../packs/cards";
 
 
 document.addEventListener('turbolinks:load', () => {
   initMapbox();
 });
+
+// document.addEventListener("turbolinks:load", () => {
+//   cardExtendDetails();
+// });
 
 document.addEventListener('turbolinks:load', () => {
   initRadarCable();

--- a/app/javascript/packs/cards.js
+++ b/app/javascript/packs/cards.js
@@ -1,0 +1,8 @@
+// const cardExtendDetails = () => {
+//   const element = document.querySelector(".card");
+//   element.addEventListener("click", (event) => {
+//     element.classList.toggle("d-none")
+//   });
+// };
+
+// export { cardExtendDetails };

--- a/app/views/radars/index.html.erb
+++ b/app/views/radars/index.html.erb
@@ -8,7 +8,7 @@
    <% @radars.each do |radar|  %>
     <div class="card">
       <div class="card-user-section-info">
-          <img class="avatar-square" src= <%= cl_image_path(radar.creator.photo.key, width: 200, height: 200, crop: :thumb, gravity: :face) %> />
+          <img class="avatar-large" src= <%= cl_image_path(radar.creator.photo.key, width: 200, height: 200, crop: :thumb, gravity: :face) %> />
           <div>
             <p style="margin: 0px; font-weight: lighter; display: inline;">Activity :</p>
             <p style="margin: 0px; font-weight: bolder; display: inline;" id="beacon-activity"> <%= Activity.find(radar.activity_id).name.capitalize %></p>
@@ -18,6 +18,23 @@
             <p style="margin: 0px; font-weight: bolder; display: inline;" id="beacon-activity"> <%= radar.time.to_time.strftime("%l:%M%p") %></p>
           </div>
           <%= link_to "Join", join_radar_path(radar), method: "POST", class: "beacon-join-button"  %>
+      </div>
+      <div class="card-user-beacon-details">
+          <div>
+            <h4><%= radar.description %></h4>
+            <hr>
+          </div>
+
+          <div>
+            <p>Participants</p>
+            <% if radar.participants.count === 0 %>
+              <p style="margin: 0px; font-weight: 200;">Empty</p>
+            <% else %>
+              <% radar.participants.each do |participant| %>
+              <img class="avatar m-1" src=<%= cl_image_path(participant.photo.key, width: 150, height: 150, crop: :thumb, gravity: :face) %>>
+              <% end %>
+            <% end %>
+          </div>
       </div>
     </div>
     <% end %>

--- a/app/views/radars/index.html.erb
+++ b/app/views/radars/index.html.erb
@@ -18,13 +18,16 @@
             <p style="margin: 0px; font-weight: bolder; display: inline;" id="beacon-activity"> <%= radar.time.to_time.strftime("%l:%M%p") %></p>
           </div>
           <%= link_to "Join", join_radar_path(radar), method: "POST", class: "beacon-join-button"  %>
+          <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#collapseDetails" aria-expanded="true" aria-controls="collapseDetails">
+          Details
+        </button>
       </div>
-      <div class="card-user-beacon-details">
+      <div class="collapse" id="collapseDetails">
+        <div class="card-user-beacon-details">
           <div>
             <h4><%= radar.description %></h4>
             <hr>
           </div>
-
           <div>
             <p>Participants</p>
             <% if radar.participants.count === 0 %>
@@ -35,6 +38,7 @@
               <% end %>
             <% end %>
           </div>
+        </div>
       </div>
     </div>
     <% end %>

--- a/app/views/radars/show.html.erb
+++ b/app/views/radars/show.html.erb
@@ -14,14 +14,14 @@
         <hr>
         <div class="d-flex justify-content-start">
           <div style="margin-top: 6px;">
-            <p style="margin: 0px">Activity</p>
-            <p style="margin: 0px" id="beacon-activity"> <%= Activity.find(@radar.activity_id).name.capitalize %></p>
+            <p style="margin: 0px; font-weight: 200;">Activity</p>
+            <p style="margin: 0px; font-weight: bolder;" id="beacon-activity"> <%= Activity.find(@radar.activity_id).name.capitalize %></p>
           </div>
           <div style="margin-top: 6px; margin-left: 30px;">
-            <p style="margin: 0px">When</p>
-            <p style="margin: 0px" id="beacon-activity"> <%= @radar.time.to_time.strftime("%l:%M%p") %></p>
+            <p style="margin: 0px; font-weight: 200;">When</p>
+            <p style="margin: 0px; font-weight: bolder;" id="beacon-activity"> <%= @radar.time.to_time.strftime("%l:%M%p") %></p>
           </div>
-          <p><%= link_to "Leave", leave_radar_path(@radar), method: "POST", class: "custom-btn custom-btn-join btn-block"%></p>
+          <p style="margin: 0px 30px 0px 70px;"><%= link_to "Leave", leave_radar_path(@radar), method: "POST", class: "custom-btn custom-btn-join"%></p>
         </div>
       </div>
       <div class="messages">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -5,18 +5,17 @@
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
-  <%= link_to "CREATE A BEACON", new_radar_path(), class: "nav-link btn btn-outline-info m-2" %>
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <ul class="navbar-nav mr-auto">
       <% if user_signed_in? %>
-        <li class="nav-item active nav-item-str">
-          <%= link_to "Home", root_path, class: "nav-link" %>
+        <li class="nav-item-str">
+          <%= link_to "CREATE A BEACON", new_radar_path(), class: "beacon-join-button" %>
         </li>
-        <li class="nav-item nav-item-str">
-          <%= link_to "Messages", "#", class: "nav-link" %>
+        <li class="nav-item-str">
+          <p>Beacon created: <%= current_user.beacon %></p>
         </li>
-        <li class="nav-item nav-item-str">
-          <p class="nav-link"><%= current_user.first_name %></p>
+        <li class="nav-item-str">
+          <p><%= current_user.first_name %></p>
         </li>
         <li class="nav-item dropdown">
           <img class="avatar-large dropdown-toggle" id="navbarDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" src=<%= cl_image_path(current_user.photo.key, width: 150, height: 150, crop: :thumb, gravity: :face) %> />

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -12,7 +12,7 @@
           <%= link_to "CREATE A BEACON", new_radar_path(), class: "beacon-join-button" %>
         </li>
         <li class="nav-item-str">
-          <p>Beacon created: <%= current_user.beacon %></p>
+          <p>Beacon created: <span><%= @radars.where(creator_id: current_user.id).count %></span> </p>
         </li>
         <li class="nav-item-str">
           <p><%= current_user.first_name %></p>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -12,7 +12,7 @@
           <%= link_to "CREATE A BEACON", new_radar_path(), class: "beacon-join-button" %>
         </li>
         <li class="nav-item-str">
-          <p>Beacon created: <span><%= @radars.where(creator_id: current_user.id).count %></span> </p>
+          <p>Beacon created: <span ><%= Radar.all.where(creator_id: current_user.id).count %></span> </p>
         </li>
         <li class="nav-item-str">
           <p><%= current_user.first_name %></p>


### PR DESCRIPTION
1. Make several changes to the index page, chatroom page as well as home page. 
2. Collapsible cards for additional details. 
3. Display number of beacon created by the user on navbar.

**Before collapse**
<img width="1431" alt="Screenshot 2022-01-15 at 12 36 16 AM" src="https://user-images.githubusercontent.com/67379210/149551575-3590f065-34f2-42f4-aacf-167a406aa2d6.png">

**After collapse**
<img width="1039" alt="Screenshot 2022-01-15 at 12 36 24 AM" src="https://user-images.githubusercontent.com/67379210/149551680-0f3968ed-0df1-45ed-86da-468f5fc84c64.png">


Chatroom design
<img width="1436" alt="Screenshot 2022-01-15 at 12 36 06 AM" src="https://user-images.githubusercontent.com/67379210/149551732-46e40dc2-c48b-4826-94e8-8b2317ed8f19.png">

Home page
<img width="876" alt="Screenshot 2022-01-15 at 12 38 33 AM" src="https://user-images.githubusercontent.com/67379210/149551804-529edac2-f831-473c-8100-c2fc45a789fd.png">

